### PR TITLE
Add GNOME 3.8 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
     "name": "Antisocial Menu",
     "description": "Removes the social elements of the user menu including status icon, status chooser, notification switch and online accounts",
     "url": "http://github.com/cnervi/gnome-shell-antisocial-menu",
-    "shell-version": ["3.6"]
+    "shell-version": ["3.6", "3.7.92", "3.8"]
 }


### PR DESCRIPTION
I tast it in GNOME Shell 3.7.92 and extension work correctly. So I add current 3.7 and 3.8 to `metadata.json`.
