### PR TITLE
Gnome Shell 3.8.2 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
     "name": "Antisocial Menu",
     "description": "Removes the social elements of the user menu including status icon, status chooser, notification switch and online accounts",
     "url": "http://github.com/cnervi/gnome-shell-antisocial-menu",
-    "shell-version": ["3.6", "3.7.92", "3.8"]
+    "shell-version": ["3.6", "3.7.92", "3.8", "3.8.2"]
 }


### PR DESCRIPTION
I tested your Extension with Gnome Shell 3.8.2 and can confirm that it works.
